### PR TITLE
Additional Features: Services, Certificates, Dynamic Weight

### DIFF
--- a/default/distsearch.conf
+++ b/default/distsearch.conf
@@ -1,0 +1,2 @@
+[replicationBlacklist]
+lookups = apps/TA-misp_es/lookups/misp_es*

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -9,11 +9,11 @@ sinkhole = false
 ###### Threat Downloads ######
 
 # Local threat intelligence lookup tables.
-#[threatlist://misp_es_certificate_intel]
-#description = Threat intelligence pertaining to certificates
-#disabled = false
-#type = threatlist
-#url = lookup://misp_es_certificate_intel
+[threatlist://misp_es_certificate_intel]
+description = Threat intelligence pertaining to certificates
+disabled = false
+type = threatlist
+url = lookup://misp_es_certificate_intel
 
 [threatlist://misp_es_domain_intel]
 description = Threat intelligence pertaining to domains
@@ -57,11 +57,11 @@ disabled = false
 type = threatlist
 url = lookup://misp_es_registry_intel
 
-#[threatlist://misp_es_service_intel]
-#description = Threat intelligence pertaining to services
-#disabled = false
-#type = threatlist
-#url = lookup://misp_es_service_intel
+[threatlist://misp_es_service_intel]
+description = Threat intelligence pertaining to services
+disabled = false
+type = threatlist
+url = lookup://misp_es_service_intel
 
 #[threatlist://misp_es_user_intel]
 #description = Threat intelligence pertaining to users

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -1,5 +1,5 @@
 [all_misp_intel]
-definition = | inputlookup misp_es_certificate_intel \
+definition = inputlookup misp_es_certificate_intel \
 | append [inputlookup misp_es_domain_intel] \
 | append [inputlookup misp_es_file_intel] \
 | append [inputlookup misp_es_http_intel] \
@@ -8,3 +8,9 @@ definition = | inputlookup misp_es_certificate_intel \
 | append [inputlookup misp_es_registry_intel] \
 | append [inputlookup misp_es_service_intel] \
 | append [inputlookup misp_es_user_intel]
+
+[misp_get_weight_from_tlp(1)]
+definition = lookup misp_weight misp_tag AS $misp_tag$ OUTPUT misp_weight AS weight\
+| eval weight=if(mvcount(weight) > 1, mvindex(weight, 0), weight), 
+       weight=coalesce(weight,1)
+args = misp_tag

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -1,0 +1,10 @@
+[all_misp_intel]
+definition = | inputlookup misp_es_certificate_intel \
+| append [inputlookup misp_es_domain_intel] \
+| append [inputlookup misp_es_file_intel] \
+| append [inputlookup misp_es_http_intel] \
+| append [inputlookup misp_es_ip_intel] \
+| append [inputlookup misp_es_process_intel] \
+| append [inputlookup misp_es_registry_intel] \
+| append [inputlookup misp_es_service_intel] \
+| append [inputlookup misp_es_user_intel]

--- a/default/managed_configurations.conf
+++ b/default/managed_configurations.conf
@@ -36,6 +36,12 @@ label       = MISP to ES IP Intel
 description = Threat intelligence pertaining to IPs
 lookup_type = adhoc
 
+[lookup:misp_es_ja3_intel]
+endpoint    = /services/data/transforms/lookups/misp_es_ja3_intel
+label       = MISP to ES JA3 Intel
+description = Threat intelligence pertaining to JA3
+lookup_type = adhoc
+
 #[lookup:misp_es_process_intel]
 #endpoint    = /services/data/transforms/lookups/misp_es_process_intel
 #label       = MISP to ES Process Intel

--- a/default/managed_configurations.conf
+++ b/default/managed_configurations.conf
@@ -1,10 +1,10 @@
 ###### Lookups ######
 
-#[lookup:misp_es_certificate_intel]
-#endpoint    = /services/data/transforms/lookups/misp_es_certificate_intel
-#label       = MISP to ES Certificate Intel
-#description = Threat intelligence pertaining to SSL certificates
-#lookup_type = adhoc
+[lookup:misp_es_certificate_intel]
+endpoint    = /services/data/transforms/lookups/misp_es_certificate_intel
+label       = MISP to ES Certificate Intel
+description = Threat intelligence pertaining to SSL certificates
+lookup_type = adhoc
 
 [lookup:misp_es_domain_intel]
 endpoint    = /services/data/transforms/lookups/misp_es_domain_intel
@@ -48,11 +48,11 @@ label       = MISP to ES Registry Intel
 description = Threat intelligence pertaining to the Windows registry 
 lookup_type = adhoc
 
-#[lookup:misp_es_service_intel]
-#endpoint    = /services/data/transforms/lookups/misp_es_service_intel
-#label       = MISP to ES Service Intel
-#description = Threat intelligence pertaining to services 
-#lookup_type = adhoc
+[lookup:misp_es_service_intel]
+endpoint    = /services/data/transforms/lookups/misp_es_service_intel
+label       = MISP to ES Service Intel
+description = Threat intelligence pertaining to services 
+lookup_type = adhoc
 
 #[lookup:misp_es_user_intel]
 #endpoint    = /services/data/transforms/lookups/misp_es_user_intel

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -5,8 +5,7 @@ enableSched = 1
 search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="ip-dst,ip-src" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval ip=misp_value\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,ip,weight\
 | outputlookup append=true misp_es_ip_intel
 
@@ -18,8 +17,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval url=if(isnull(misp_url),misp_hostname,misp_url)\
 | eval http_user_agent=misp_user_agent\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,http_referrer,http_user_agent,url,weight\
 | outputlookup append=true misp_es_http_intel
 
@@ -30,8 +28,7 @@ enableSched = 1
 search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type=domain to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval domain=misp_domain\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,domain,weight\
 | outputlookup append=true misp_es_domain_intel
 
@@ -44,8 +41,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | eval file_hash=mvappend(misp_sha1,misp_sha256,misp_sha512,misp_ssdeep,misp_md5)\
 | mvexpand file_hash\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,file_hash,file_name,weight\
 | outputlookup append=true misp_es_file_intel
 
@@ -59,8 +55,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval registry_value_name=mvindex(registry,0)\
 | eval registry_value_text=mvindex(registry,1)\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,registry_path,registry_value_name,registry_value_text,weight\
 | outputlookup append=true misp_es_registry_intel
 
@@ -73,8 +68,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval subject=misp_email_subject\
 | eval file_name=misp_email_attachment\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,src_user,subject,weight,file_name\
 | outputlookup append=true misp_es_email_intel
 
@@ -89,8 +83,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
       certificate_subject_email=misp_whois_registrant_email,\
       certificate_issuer_common_name=misp_whois_registrar\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table certificate_issuer,certificate_subject,certificate_issuer_organization,certificate_subject_organization,certificate_serial,certificate_issuer_unit,certificate_subject_unit,certificate_issuer_common_name,certificate_subject_common_name,certificate_issuer_email,certificate_subject_email,certificate_file_hash,description,weight\
 | outputlookup append=true misp_es_certificate_intel
 
@@ -102,8 +95,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval service=misp_windows_service_name,\
       descriptive_name=misp_windows_service_displayname\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-| eval weight=coalesce(weight,1)\
+| `misp_get_weight_from_tlp(misp_tag)`\
 | table description,service,descriptive_name,service_file_hash,service_dll_file_hash,weight\
 | outputlookup append=true misp_es_service_intel
 
@@ -115,8 +107,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
 #| eval user = {Placeholder for custom criteria}\
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-#| eval weight=coalesce(weight,1)\
+#| `misp_get_weight_from_tlp(misp_tag)`\
 #| table description,user,weight\
 #| outputlookup append=true misp_es_user_intel
 
@@ -126,7 +117,6 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
 #| eval process = {Placeholder for custom criteria} \
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
-#| eval weight=coalesce(weight,1)\
+#| `misp_get_weight_from_tlp(misp_tag)`\
 #| table description,process,process_file_name,weight\
 #| outputlookup append=true misp_es_process_intel

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -45,6 +45,17 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | table description,file_hash,file_name,weight\
 | outputlookup append=true misp_es_file_intel
 
+[MISP_ES_ja3_intel]
+cron_schedule = 0 4 * * *
+dispatch.earliest_time =
+enableSched = 1
+search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="ja3-fingerprint-md5" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
+| eval ja3=ja3-fingerprint-md5\
+| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
+| `misp_get_weight_from_tlp(misp_tag)`\
+| table description,ja3,weight\
+| outputlookup append=true misp_es_ja3_intel
+
 [MISP_ES_registry_intel]
 cron_schedule = 0 8 * * *
 dispatch.earliest_time = 

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -46,7 +46,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | outputlookup append=true misp_es_file_intel
 
 [MISP_ES_ja3_intel]
-cron_schedule = 0 4 * * *
+cron_schedule = 0 9 * * *
 dispatch.earliest_time =
 enableSched = 1
 search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="ja3-fingerprint-md5" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -2,10 +2,14 @@
 cron_schedule = 0 7 * * *
 dispatch.earliest_time = 
 enableSched = 1
-search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="ip-dst" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
+search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="ip-dst,ip-src" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval ip=misp_value\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight = 1\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                   misp_tag=="tlp:green", 10,\
+                   misp_tag=="tlp:amber", 20,\
+                   misp_tag=="tlp:red", 30,\
+                   1==1, 1)\
 | table description,ip,weight\
 | outputlookup append=true misp_es_ip_intel
 
@@ -17,7 +21,11 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval url=if(isnull(misp_url),misp_hostname,misp_url)\
 | eval http_user_agent=misp_user_agent\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight = 1\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                   misp_tag=="tlp:green", 10,\
+                   misp_tag=="tlp:amber", 20,\
+                   misp_tag=="tlp:red", 30,\
+                   1==1, 1)\
 | table description,http_referrer,http_user_agent,url,weight\
 | outputlookup append=true misp_es_http_intel
 
@@ -28,7 +36,11 @@ enableSched = 1
 search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type=domain to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval domain=misp_domain\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight = 1\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                   misp_tag=="tlp:green", 10,\
+                   misp_tag=="tlp:amber", 20,\
+                   misp_tag=="tlp:red", 30,\
+                   1==1, 1)\
 | table description,domain,weight\
 | outputlookup append=true misp_es_domain_intel
 
@@ -41,7 +53,11 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | eval file_hash=mvappend(misp_sha1,misp_sha256,misp_sha512,misp_ssdeep,misp_md5)\
 | mvexpand file_hash\
-| eval weight = 1\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                   misp_tag=="tlp:green", 10,\
+                   misp_tag=="tlp:amber", 20,\
+                   misp_tag=="tlp:red", 30,\
+                   1==1, 1)\
 | table description,file_hash,file_name,weight\
 | outputlookup append=true misp_es_file_intel
 
@@ -55,7 +71,11 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval registry_value_name=mvindex(registry,0)\
 | eval registry_value_text=mvindex(registry,1)\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight = 1\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                   misp_tag=="tlp:green", 10,\
+                   misp_tag=="tlp:amber", 20,\
+                   misp_tag=="tlp:red", 30,\
+                   1==1, 1)\
 | table description,registry_path,registry_value_name,registry_value_text,weight\
 | outputlookup append=true misp_es_registry_intel
 
@@ -63,26 +83,55 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 cron_schedule = 0 4 * * *
 dispatch.earliest_time =
 enableSched = 1
-search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="email-src,email-subject" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
+search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="email-src,email-subject,email-attachment" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval src_user=misp_email_src\
 | eval subject=misp_email_subject\
+| eval file_name=misp_email_attachment\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight = 1\
-| table description,src_user,subject,weight\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                   misp_tag=="tlp:green", 10,\
+                   misp_tag=="tlp:amber", 20,\
+                   misp_tag=="tlp:red", 30,\
+                   1==1, 1)\
+| table description,src_user,subject,weight,file_name\
 | outputlookup append=true misp_es_email_intel
 
+[MISP_ES_certificate_intel]
+cron_schedule = 0 2 * * *
+enableSched = 1
+dispatch.earliest_time = 
+search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true geteventtag=true warning_list=true limit=0 last=1d type="misp_x509_fingerprint_sha256,misp_x509_fingerprint_sha1,misp_x509_fingerprint_md5"\
+| eval certificate_file_hash = coalesce(misp_x509_fingerprint_sha256, misp_x509_fingerprint_sha1,misp_x509_fingerprint_md5,whois-registrar,whois-registrant-name,whois-registrant-org,whois-registrant-email)\
+| eval certificate_subject_organization=misp_whois_registrant_org,\
+      certificate_subject_common_name=misp_whois_registrant_name,\
+      certificate_subject_email=misp_whois_registrant_email,\
+      certificate_issuer_common_name=misp_whois_registrar\
+| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                  misp_tag=="tlp:green", 10,\
+                  misp_tag=="tlp:amber", 20,\
+                  misp_tag=="tlp:red", 30,\
+                  1==1, 1)\
+| table certificate_issuer,certificate_subject,certificate_issuer_organization,certificate_subject_organization,certificate_serial,certificate_issuer_unit,certificate_subject_unit,certificate_issuer_common_name,certificate_subject_common_name,certificate_issuer_email,certificate_subject_email,certificate_file_hash,description,weight\
+| outputlookup append=true misp_es_certificate_intel
+
+[MISP_ES_service_intel]
+cron_schedule = 0 1 * * *
+enableSched = 1
+dispatch.earliest_time = 
+search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d type="windows-service-name,windows-service-displayname"\
+| eval service=misp_windows_service_name,\
+      descriptive_name=misp_windows_service_displayname\
+| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
+| eval weight=case(misp_tag=="tlp:white", 5,\
+                  misp_tag=="tlp:green", 10,\
+                  misp_tag=="tlp:amber", 20,\
+                  misp_tag=="tlp:red", 30,\
+                  1==1, 1)\
+| table description,service,descriptive_name,service_file_hash,service_dll_file_hash,weight\
+| outputlookup append=true misp_es_service_intel
 
 # These searches do not neatly fit with indicators in MISP today. They can be modified as you see fit to meet your own MISP configuation.
-
-#[MISP_ES_certificate_intel]
-#enableSched = 1
-#dispatch.earliest_time = 
-#search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
-#| eval user = {Placeholder for custom criteria}\
-#| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| eval weight = 1\
-#| table certificate_issuer,certificate_subject,certificate_issuer_organization,certificate_subject_organization,certificate_serial,certificate_issuer_unit,certificate_subject_unit,description,weight\
-#| outputlookup append=true misp_es_certificate_intel
 
 #[MISP_ES_user_intel]
 #enableSched = 1
@@ -90,19 +139,13 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
 #| eval user = {Placeholder for custom criteria}\
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| eval weight = 1\
+#| eval weight=case(misp_tag=="tlp:white", 5,\
+#                   misp_tag=="tlp:green", 10,\
+#                   misp_tag=="tlp:amber", 20,\
+#                   misp_tag=="tlp:red", 30,\
+#                   1==1, 1)\
 #| table description,user,weight\
 #| outputlookup append=true misp_es_user_intel
-
-#[MISP_ES_service_intel]
-#enableSched = 1
-#dispatch.earliest_time = 
-#search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
-#| eval service_file_hash = {Placeholder for custom criteria} \
-#| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| eval weight = 1\
-#| table description,service,service_file_hash,service_dll_file_hash,weight\
-#| outputlookup append=true misp_es_service_intel
 
 #[MISP_ES_process_intel]
 #enableSched = 1
@@ -110,6 +153,10 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
 #| eval process = {Placeholder for custom criteria} \
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| eval weight = 1\
+#| eval weight=case(misp_tag=="tlp:white", 5,\
+#                   misp_tag=="tlp:green", 10,\
+#                   misp_tag=="tlp:amber", 20,\
+#                   misp_tag=="tlp:red", 30,\
+#                   1==1, 1)\
 #| table description,process,process_file_name,weight\
 #| outputlookup append=true misp_es_process_intel

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -5,11 +5,7 @@ enableSched = 1
 search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type="ip-dst,ip-src" to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval ip=misp_value\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                   misp_tag=="tlp:green", 10,\
-                   misp_tag=="tlp:amber", 20,\
-                   misp_tag=="tlp:red", 30,\
-                   1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,ip,weight\
 | outputlookup append=true misp_es_ip_intel
 
@@ -21,11 +17,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval url=if(isnull(misp_url),misp_hostname,misp_url)\
 | eval http_user_agent=misp_user_agent\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                   misp_tag=="tlp:green", 10,\
-                   misp_tag=="tlp:amber", 20,\
-                   misp_tag=="tlp:red", 30,\
-                   1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,http_referrer,http_user_agent,url,weight\
 | outputlookup append=true misp_es_http_intel
 
@@ -36,11 +28,7 @@ enableSched = 1
 search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" type=domain to_ids=true geteventtag=true warning_list=true limit=0 last=1d\
 | eval domain=misp_domain\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                   misp_tag=="tlp:green", 10,\
-                   misp_tag=="tlp:amber", 20,\
-                   misp_tag=="tlp:red", 30,\
-                   1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,domain,weight\
 | outputlookup append=true misp_es_domain_intel
 
@@ -53,11 +41,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | eval file_hash=mvappend(misp_sha1,misp_sha256,misp_sha512,misp_ssdeep,misp_md5)\
 | mvexpand file_hash\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                   misp_tag=="tlp:green", 10,\
-                   misp_tag=="tlp:amber", 20,\
-                   misp_tag=="tlp:red", 30,\
-                   1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,file_hash,file_name,weight\
 | outputlookup append=true misp_es_file_intel
 
@@ -71,11 +55,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval registry_value_name=mvindex(registry,0)\
 | eval registry_value_text=mvindex(registry,1)\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                   misp_tag=="tlp:green", 10,\
-                   misp_tag=="tlp:amber", 20,\
-                   misp_tag=="tlp:red", 30,\
-                   1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,registry_path,registry_value_name,registry_value_text,weight\
 | outputlookup append=true misp_es_registry_intel
 
@@ -88,11 +68,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval subject=misp_email_subject\
 | eval file_name=misp_email_attachment\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                   misp_tag=="tlp:green", 10,\
-                   misp_tag=="tlp:amber", 20,\
-                   misp_tag=="tlp:red", 30,\
-                   1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,src_user,subject,weight,file_name\
 | outputlookup append=true misp_es_email_intel
 
@@ -107,11 +83,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
       certificate_subject_email=misp_whois_registrant_email,\
       certificate_issuer_common_name=misp_whois_registrar\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                  misp_tag=="tlp:green", 10,\
-                  misp_tag=="tlp:amber", 20,\
-                  misp_tag=="tlp:red", 30,\
-                  1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table certificate_issuer,certificate_subject,certificate_issuer_organization,certificate_subject_organization,certificate_serial,certificate_issuer_unit,certificate_subject_unit,certificate_issuer_common_name,certificate_subject_common_name,certificate_issuer_email,certificate_subject_email,certificate_file_hash,description,weight\
 | outputlookup append=true misp_es_certificate_intel
 
@@ -123,11 +95,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval service=misp_windows_service_name,\
       descriptive_name=misp_windows_service_displayname\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-| eval weight=case(misp_tag=="tlp:white", 5,\
-                  misp_tag=="tlp:green", 10,\
-                  misp_tag=="tlp:amber", 20,\
-                  misp_tag=="tlp:red", 30,\
-                  1==1, 1)\
+| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 | table description,service,descriptive_name,service_file_hash,service_dll_file_hash,weight\
 | outputlookup append=true misp_es_service_intel
 
@@ -139,11 +107,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
 #| eval user = {Placeholder for custom criteria}\
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| eval weight=case(misp_tag=="tlp:white", 5,\
-#                   misp_tag=="tlp:green", 10,\
-#                   misp_tag=="tlp:amber", 20,\
-#                   misp_tag=="tlp:red", 30,\
-#                   1==1, 1)\
+#| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 #| table description,user,weight\
 #| outputlookup append=true misp_es_user_intel
 
@@ -153,10 +117,6 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #search = | mispgetioc misp_instance=misp_covid add_description=true category="External analysis,Financial fraud,Internal reference,Network activity,Other,Payload delivery,Payload installation,Payload type,Persistence mechanism,Person,Social network,Support Tool,Targeting data" to_ids=true  geteventtag=true warning_list=true limit=0 last=1d\
 #| eval process = {Placeholder for custom criteria} \
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
-#| eval weight=case(misp_tag=="tlp:white", 5,\
-#                   misp_tag=="tlp:green", 10,\
-#                   misp_tag=="tlp:amber", 20,\
-#                   misp_tag=="tlp:red", 30,\
-#                   1==1, 1)\
+#| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
 #| table description,process,process_file_name,weight\
 #| outputlookup append=true misp_es_process_intel

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -6,6 +6,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval ip=misp_value\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,ip,weight\
 | outputlookup append=true misp_es_ip_intel
 
@@ -18,6 +19,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval http_user_agent=misp_user_agent\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,http_referrer,http_user_agent,url,weight\
 | outputlookup append=true misp_es_http_intel
 
@@ -29,6 +31,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval domain=misp_domain\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,domain,weight\
 | outputlookup append=true misp_es_domain_intel
 
@@ -42,6 +45,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval file_hash=mvappend(misp_sha1,misp_sha256,misp_sha512,misp_ssdeep,misp_md5)\
 | mvexpand file_hash\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,file_hash,file_name,weight\
 | outputlookup append=true misp_es_file_intel
 
@@ -56,6 +60,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval registry_value_text=mvindex(registry,1)\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,registry_path,registry_value_name,registry_value_text,weight\
 | outputlookup append=true misp_es_registry_intel
 
@@ -69,6 +74,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 | eval file_name=misp_email_attachment\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,src_user,subject,weight,file_name\
 | outputlookup append=true misp_es_email_intel
 
@@ -84,6 +90,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
       certificate_issuer_common_name=misp_whois_registrar\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table certificate_issuer,certificate_subject,certificate_issuer_organization,certificate_subject_organization,certificate_serial,certificate_issuer_unit,certificate_subject_unit,certificate_issuer_common_name,certificate_subject_common_name,certificate_issuer_email,certificate_subject_email,certificate_file_hash,description,weight\
 | outputlookup append=true misp_es_certificate_intel
 
@@ -96,6 +103,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
       descriptive_name=misp_windows_service_displayname\
 | eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 | lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+| eval weight=coalesce(weight,1)\
 | table description,service,descriptive_name,service_file_hash,service_dll_file_hash,weight\
 | outputlookup append=true misp_es_service_intel
 
@@ -108,6 +116,7 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #| eval user = {Placeholder for custom criteria}\
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 #| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+#| eval weight=coalesce(weight,1)\
 #| table description,user,weight\
 #| outputlookup append=true misp_es_user_intel
 
@@ -118,5 +127,6 @@ search = | mispgetioc misp_instance=misp_covid add_description=true category="Ex
 #| eval process = {Placeholder for custom criteria} \
 #| eval description = tostring(misp_event_info)."|".tostring(misp_category)."|".tostring(misp_comment)\
 #| lookup misp_weight misp_tag AS misp_tag OUTPUT misp_weight AS weight\
+#| eval weight=coalesce(weight,1)\
 #| table description,process,process_file_name,weight\
 #| outputlookup append=true misp_es_process_intel

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -24,6 +24,9 @@ filename = misp_es_certificate_intel.csv
 [misp_es_service_intel]
 filename = misp_es_service_intel.csv
 
+[misp_weight]
+filename = misp_weight.csv
+
 #[misp_es_process_intel]
 #filename = misp_es_process_intel.csv
 

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -21,6 +21,9 @@ filename = misp_es_registry_intel.csv
 [misp_es_certificate_intel]
 filename = misp_es_certificate_intel.csv
 
+[misp_es_ja3_intel]
+filename = misp_es_ja3_intel.csv
+
 [misp_es_service_intel]
 filename = misp_es_service_intel.csv
 

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -18,14 +18,14 @@ filename = misp_es_ip_intel.csv
 [misp_es_registry_intel]
 filename = misp_es_registry_intel.csv
 
-#[misp_es_certificate_intel]
-#filename = misp_es_certificate_intel.cs
+[misp_es_certificate_intel]
+filename = misp_es_certificate_intel.csv
+
+[misp_es_service_intel]
+filename = misp_es_service_intel.csv
 
 #[misp_es_process_intel]
 #filename = misp_es_process_intel.csv
-
-#[misp_es_service_intel]
-#filename = misp_es_service_intel.csv
 
 #[misp_es_user_intel]
 #filename = misp_es_user_intel.csv

--- a/lookups/misp_es_ja3_intel.csv
+++ b/lookups/misp_es_ja3_intel.csv
@@ -1,0 +1,1 @@
+ja3,description,weight

--- a/lookups/misp_weight.csv
+++ b/lookups/misp_weight.csv
@@ -1,0 +1,5 @@
+misp_tag,misp_weight
+tlp:white,5
+tlp:green,10
+tlp:amber,20
+tlp:red,30


### PR DESCRIPTION
# Summary

This PR maps MISP service intelligence and certificate intelligence to Splunk intelligence uses and utilizes an additional lookup to provide dynamic weighting of MISP IoCs based on TLP tagging. It also fixes a typo in the certificate intelligence filename of the app's transforms.

## Purpose

The purpose of this PR is to bring additional functionality to the MISP threat collections and add more built-in features that help users create intelligence-based decisions and events.

## Details

- Fixed a typo in the `transforms.conf` in the `misp_es_certificate_intel` stanza with the `filename` line
- Added conveinience macro for getting all MISP intel in ES, and macro for looking up `misp_weight`
- Uncommented the certificate and service lookup definitions, inputs, and managed configurations, as well as adding a `misp_weight` lookup definition
- Added MISP type `email-attachment` to email intelligence
- Added MISP type `ip-src` to IP intelligence
- Added lookup `misp_weight.csv` and a lookup line to each saved search which grabs the TLP tag and outputs a numeric weighting based on the field
- Mapped the following Splunk intelligence fields to MISP types:

### Certificate Intelligence

- `certificate_issuer_common_name` = `whois-registrar`
- `certificate_subject_common_name` = `whois-registrant-name`
- `certificate_subject_email` = `whois-registrant-email`
- `certificate_subject_organization` = `whois-registrant-org`
- `certificate_file_hash` = coalesce
  - `x509-fingerprint-md5`
  - `x509-fingerprint-sha1`
  - `x509-fingerprint-sha256`

### Service Intelligence
- `service` = `windows-service-name`
- `descriptive_name` = `windows-service-displayname`